### PR TITLE
Textbox funcs galore

### DIFF
--- a/BPRE.ld
+++ b/BPRE.ld
@@ -69,6 +69,28 @@ memset = 0x081E5ED8|1;
 template_instanciate_forward_search = 0x08006F8C|1;
 obj_delete = 0x080073DC|1;
 
+rboxid_clear_pixels = 0x0800445C|1;
+rboxid_08003FA0 =  0x08003FA0|1;
+rboxid_to_vram = 0x08003F20|1;
+something_08050DE1 = 0x08050DE0|1;
+gpu_tile_obj_alloc_tag_and_upload = 0x080086DC|1;
+gpu_tile_obj_alloc_tag_and_apply = 0x08008928|1;
+gpu_sync_bg_show = 0x080019BC|1;
+something_08050969 = 0x08050968|1;
+box_print = 0x0812E51C|1;
+sub_0800F380 = 0x0800F380|1;
+sub_0800F34C = 0x0800F34C|1;
+strcpy_xFF_terminated = 0x08008D84|1;
+sub_080F6EE4 = 0x080F6EE4|1;
+box_related_one = 0x080F6CD0|1;
+sav2_get_text_speed = 0x080F78A8|1;
+rboxid_to_vram = 0x08003F20|1;
+sub_81220D4 = 0x081220D4|1;
+box_curved = 0x080F7768|1;
+sub_080F696C = 0x080F696C|1;
+sub_08002040 = 0x08002040|1;
+gpu_sync_bg_show = 0x80019BC|1;
+
 /*
  * Custom Data
  */

--- a/src/textbox.c
+++ b/src/textbox.c
@@ -1,0 +1,53 @@
+#include "types.h"
+#include "textbox.h"
+
+
+/* TODO: Make cutscript functions which use these */
+
+void textbox_set_text(u8 *string, u8 font, u8 text_bg, u8 text_colour, u8 shadow, u8 text_bg_box) {
+	textflags.unknown[0] = textflags.unknown[0] | 1;
+	if (text_bg_box) {
+		rboxid_clear_pixels(0, 0xFF); // transparent
+	} else {
+		rboxid_clear_pixels(0, 0x11); // white
+	}
+	rboxid_08003FA0(0);
+	rboxid_to_vram(0, 0);
+	box_related_one(0, font, string, sav2_get_text_speed(), 0, text_colour, text_bg, shadow);
+}
+
+void create_battle_box() {
+	// this is for the textbox that comes up during battle
+	sub_0800F34C();
+	lz77_uncomp_vram((void *)0x8D00000, (void *)0x6000000);
+	sub_080F696C(0, 0x8D00000, 0, 0, 0);
+	sub_08002040(0, 0x8D0051C, 0, 0);
+	bgid_send_tilemap(0);
+	pal_decompress_slice_to_faded_and_unfaded((void *)0x8D004D8, 0, 0x40);
+}
+
+void create_curved_box() {
+	// this is for the standard textbox in scripts
+	box_curved(0, 1);
+}
+
+void display_textbox() {
+	gpu_sync_bg_show(0);
+}
+
+void quick_setup_textbox(u8 string_id) {
+	create_battle_box();
+	display_textbox();
+	//textbox_set_text((u8 *)0x81C55C9, 1, 0, 1, 3, 1);
+	textbox_set_text(battle_strings.string[string_id], 1, 0, 1, 3);
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/textbox.h
+++ b/src/textbox.h
@@ -1,0 +1,28 @@
+#ifndef TEXTBOX_RELATED_H
+#define TEXTBOX_RELATED_H
+
+struct strings_to_display {
+	u8 *string[50]; // I have it as 50 now. Strings need to be ROM pointers
+};
+
+struct textflags {
+	u8 unknown[4];
+};
+
+void box_related_one(u8, u8, u8* string, u8, u8, u8, u8, u8);
+void rboxid_to_vram(u8, u8);
+void box_curved(u8, u8);
+void sub_080F696C(u8, u32, u8, u8, u8);
+void sub_08002040(u8, u32, u8, u8);
+void gpu_sync_bg_show(u8);
+void bgid_send_tilemap(u8);
+void rboxid_clear_pixels(u8, u8);
+void rboxid_08003FA0(u8);
+void sub_0800F34C(void);
+u8 sav2_get_text_speed(void);
+void lz77_uncomp_vram(void* src, void* dst);
+
+extern struct textflags textflags;
+extern struct strings_to_display strings_to_display;
+
+#endif /* TEXTBOX_RELATED_H */


### PR DESCRIPTION
I leave it to you to make cutscript commands which use these.

Info:

unframed_text_box_init - whiteout style text. Transparent background

quick_setup_textbox - battle textbox

create_curved_box - standard message textbox

textbox_set_text - for battle box and curved box. Puts text in them, obviously.

I have not tested unframed textbox fully, I leave that to you (I have tested the ASM version I made). The others are tested. 
